### PR TITLE
Leaderboards

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,7 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/gomodule/redigo v1.7.1-0.20190322064113-39e2c31b7ca3/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
 github.com/gomodule/redigo v2.0.0+incompatible h1:K/R+8tc58AaqLkqG2Ol3Qk+DR/TlNuhuh457pBFPtt0=
 github.com/gomodule/redigo v2.0.0+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
+github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/googleapis/gax-go v2.0.2+incompatible h1:silFMLAnr330+NRuag/VjIGF7TLp/LBrV2CJKFLWEww=
 github.com/googleapis/gax-go v2.0.2+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=

--- a/pkg/collective/collective.go
+++ b/pkg/collective/collective.go
@@ -19,6 +19,7 @@ import (
 const (
 	defaultMinStepTimeMilliseconds int64 = 250 // 50
 	entitiesPollWaitTime           int64 = 250
+	newGenerationPenaltyWaitTime   int64 = 1000
 )
 
 type collectiveServer struct {
@@ -128,7 +129,9 @@ func (s *collectiveServer) ConnectRemoteModel(stream api.Collective_ConnectRemot
 
 		// If there are no entities, wait the default poll time and then restart the loop
 		if len(entities) == 0 {
-			time.Sleep(time.Duration(entitiesPollWaitTime) * time.Millisecond)
+			// Wait the penalty
+			time.Sleep(time.Duration(newGenerationPenaltyWaitTime) * time.Millisecond)
+			s.envClient.CreateEntity(ctx, &envApi.CreateEntityRequest{Entity: &envApi.Entity{ModelID: remoteModelMD.ID}})
 		}
 
 		// Create a new observation packet to send

--- a/pkg/collective/collective.go
+++ b/pkg/collective/collective.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	b64 "encoding/base64"
+
 	datacom "github.com/terrariumai/simulation/pkg/datacom"
 
 	api "github.com/terrariumai/simulation/pkg/api/collective"
@@ -132,7 +134,12 @@ func (s *collectiveServer) ConnectRemoteModel(stream api.Collective_ConnectRemot
 			// Wait the penalty
 			time.Sleep(time.Duration(newGenerationPenaltyWaitTime) * time.Millisecond)
 			// Spawn entity with invalid x to force random placement
-			s.envClient.CreateEntity(ctx, &envApi.CreateEntityRequest{Entity: &envApi.Entity{X: 999999999, ModelID: remoteModelMD.ID, ClassID: envApi.Entity_AGENT}})
+			// Get owner uid from the remote model, generate auth context and make request
+			userinfoJSONString := fmt.Sprintf("{\"id\":\"%s\"}", remoteModelMD.OwnerUID)
+			userinfoEnc := b64.StdEncoding.EncodeToString([]byte(userinfoJSONString))
+			md := metadata.Pairs("x-endpoint-api-userinfo", userinfoEnc)
+			envCtx := metadata.NewOutgoingContext(context.Background(), md)
+			s.envClient.CreateEntity(envCtx, &envApi.CreateEntityRequest{Entity: &envApi.Entity{X: 999999999, ModelID: remoteModelMD.ID, OwnerUID: remoteModelMD.OwnerUID, ClassID: envApi.Entity_AGENT}})
 		}
 
 		// Create a new observation packet to send

--- a/pkg/collective/collective.go
+++ b/pkg/collective/collective.go
@@ -131,7 +131,8 @@ func (s *collectiveServer) ConnectRemoteModel(stream api.Collective_ConnectRemot
 		if len(entities) == 0 {
 			// Wait the penalty
 			time.Sleep(time.Duration(newGenerationPenaltyWaitTime) * time.Millisecond)
-			s.envClient.CreateEntity(ctx, &envApi.CreateEntityRequest{Entity: &envApi.Entity{ModelID: remoteModelMD.ID}})
+			// Spawn entity with invalid x to force random placement
+			s.envClient.CreateEntity(ctx, &envApi.CreateEntityRequest{Entity: &envApi.Entity{X: 999999999, ModelID: remoteModelMD.ID, ClassID: envApi.Entity_AGENT}})
 		}
 
 		// Create a new observation packet to send

--- a/pkg/datacom/firebase.go
+++ b/pkg/datacom/firebase.go
@@ -126,11 +126,11 @@ func (dc *Datacom) AddEntityMetadataToFireabase(e envApi.Entity) error {
 	}
 
 	_, err = client.Collection("entities").Doc(e.Id).Set(ctx, map[string]interface{}{
-		"Id":       e.Id,
-		"OwnerUID": e.OwnerUID,
-		"ModelID":  e.ModelID,
-		"ClassID":  e.ClassID,
-		"CreatedAt": time.Now(),
+		"id":        e.Id,
+		"owner":     e.OwnerUID,
+		"model":     e.ModelID,
+		"classId":   e.ClassID,
+		"createdAt": time.Now(),
 	}, firestore.MergeAll)
 	return err
 }

--- a/pkg/datacom/firebase.go
+++ b/pkg/datacom/firebase.go
@@ -7,6 +7,7 @@ import (
 	"log"
 
 	"cloud.google.com/go/firestore"
+	envApi "github.com/terrariumai/simulation/pkg/api/environment"
 )
 
 // GetRemoteModelMetadataBySecret checks the database to see if a remote model exists,
@@ -111,4 +112,40 @@ func (dc *Datacom) UpdateRemoteModelMetadata(remoteModelMD *RemoteModel, connect
 	}
 
 	return nil
+}
+
+// AddEntityMetadataToFireabse adds an entity's metadata to firebase
+func (dc *Datacom) AddEntityMetadataToFireabse(e envApi.Entity) error {
+	// Init client
+	ctx := context.Background()
+	client, err := dc.firebaseApp.Firestore(ctx)
+	defer client.Close()
+	if err != nil {
+		return err
+	}
+
+	_, err = client.Collection("remoteModels").Doc(e.Id).Set(ctx, map[string]interface{}{
+		"Id":       e.Id,
+		"OwnerUID": e.OwnerUID,
+		"ModelID":  e.ModelID,
+		"ClassID":  e.ClassID,
+	}, firestore.MergeAll)
+	if err != nil {
+		fmt.Printf("ERROR: %v", err)
+	}
+
+	return err
+}
+
+// RemoveEntityMetadataFromFirebase remove entity metadata
+func (dc *Datacom) RemoveEntityMetadataFromFirebase(id string) error {
+	// Init client
+	ctx := context.Background()
+	client, err := dc.firebaseApp.Firestore(ctx)
+	defer client.Close()
+	if err != nil {
+		return err
+	}
+	_, err = client.Collection("remoteModels").Doc(id).Delete(ctx)
+	return err
 }

--- a/pkg/datacom/firebase.go
+++ b/pkg/datacom/firebase.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"time"
 
 	"cloud.google.com/go/firestore"
 	envApi "github.com/terrariumai/simulation/pkg/api/environment"
@@ -114,8 +115,8 @@ func (dc *Datacom) UpdateRemoteModelMetadata(remoteModelMD *RemoteModel, connect
 	return nil
 }
 
-// AddEntityMetadataToFireabse adds an entity's metadata to firebase
-func (dc *Datacom) AddEntityMetadataToFireabse(e envApi.Entity) error {
+// AddEntityMetadataToFireabase adds an entity's metadata to firebase
+func (dc *Datacom) AddEntityMetadataToFireabase(e envApi.Entity) error {
 	// Init client
 	ctx := context.Background()
 	client, err := dc.firebaseApp.Firestore(ctx)
@@ -124,16 +125,13 @@ func (dc *Datacom) AddEntityMetadataToFireabse(e envApi.Entity) error {
 		return err
 	}
 
-	_, err = client.Collection("remoteModels").Doc(e.Id).Set(ctx, map[string]interface{}{
+	_, err = client.Collection("entities").Doc(e.Id).Set(ctx, map[string]interface{}{
 		"Id":       e.Id,
 		"OwnerUID": e.OwnerUID,
 		"ModelID":  e.ModelID,
 		"ClassID":  e.ClassID,
+		"CreatedAt": time.Now(),
 	}, firestore.MergeAll)
-	if err != nil {
-		fmt.Printf("ERROR: %v", err)
-	}
-
 	return err
 }
 
@@ -146,6 +144,6 @@ func (dc *Datacom) RemoveEntityMetadataFromFirebase(id string) error {
 	if err != nil {
 		return err
 	}
-	_, err = client.Collection("remoteModels").Doc(id).Delete(ctx)
+	_, err = client.Collection("entities").Doc(id).Delete(ctx)
 	return err
 }

--- a/pkg/datacom/firebase.go
+++ b/pkg/datacom/firebase.go
@@ -117,6 +117,10 @@ func (dc *Datacom) UpdateRemoteModelMetadata(remoteModelMD *RemoteModel, connect
 
 // AddEntityMetadataToFireabase adds an entity's metadata to firebase
 func (dc *Datacom) AddEntityMetadataToFireabase(e envApi.Entity) error {
+	// Training case
+	if dc.env == "training" {
+		return nil
+	}
 	// Init client
 	ctx := context.Background()
 	client, err := dc.firebaseApp.Firestore(ctx)
@@ -137,6 +141,10 @@ func (dc *Datacom) AddEntityMetadataToFireabase(e envApi.Entity) error {
 
 // RemoveEntityMetadataFromFirebase remove entity metadata
 func (dc *Datacom) RemoveEntityMetadataFromFirebase(id string) error {
+	// Training case
+	if dc.env == "training" {
+		return nil
+	}
 	// Init client
 	ctx := context.Background()
 	client, err := dc.firebaseApp.Firestore(ctx)

--- a/pkg/datacom/pubnub.go
+++ b/pkg/datacom/pubnub.go
@@ -70,7 +70,7 @@ func (p *PubnubPAL) QueuePublishEvent(eventName string, protoMsg proto.Message, 
 	}
 
 	regionX, regionY := getRegionForPos(x, y)
-	channel := fmt.Sprintf("%v.%v", regionX, regionY)
+	channel := fmt.Sprintf("%v-%v", regionX, regionY)
 
 	p.pubChan <- pubMsg{
 		channel,

--- a/pkg/datacom/redis.go
+++ b/pkg/datacom/redis.go
@@ -357,7 +357,7 @@ func (dc *Datacom) GetEntitiesInSpace(x0 uint32, y0 uint32, x1 uint32, y1 uint32
 	for _, content := range contentArray {
 		entity, _ := parseEntityContent(content)
 		// Ignore entities outside space
-		if entity.X < x0 || entity.X > x1 || entity.X < y0 || entity.X > y1 {
+		if entity.X < x0 || entity.X > x1 || entity.Y < y0 || entity.Y > y1 {
 			continue
 		}
 		entities = append(entities, &entity)

--- a/pkg/datacom/redis.go
+++ b/pkg/datacom/redis.go
@@ -376,7 +376,6 @@ func (dc *Datacom) CreateEffect(effect envApi.Effect) error {
 		effect.Timestamp = time.Now().Unix()
 	}
 	content, err := serializeEffect(effect)
-	fmt.Println(content)
 	if err != nil {
 		log.Println("ERROR: ", err)
 		return err

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	maxPosition            = 999
+	maxPosition            = 100
 	minPosition            = 0
 	regionSize             = 10
 	maxUserCreatedEntities = 5
@@ -85,6 +85,10 @@ func NewEnvironmentServer(env string, d DataAccessLayer) envApi.EnvironmentServe
 	}
 
 	return s
+}
+
+func randomPosition() (uint32, uint32) {
+	return uint32(rand.Intn(maxPosition)), uint32(rand.Intn(maxPosition))
 }
 
 // Get data for an entity
@@ -152,16 +156,11 @@ func (s *environmentServer) CreateEntity(ctx context.Context, req *envApi.Create
 		return nil, err
 	}
 
-	// Validate position
-	if req.Entity.X < minPosition || req.Entity.Y < minPosition {
-		err := errors.New("invalid position")
-		log.Printf("ERROR: %v\n", err)
-		return nil, err
-	}
-	if req.Entity.X > maxPosition || req.Entity.Y > maxPosition {
-		err := errors.New("invalid position")
-		log.Printf("ERROR: %v\n", err)
-		return nil, err
+	// If invalid posiiton, create new random position in the range
+	if req.Entity.X < minPosition || req.Entity.Y < minPosition || req.Entity.X > maxPosition || req.Entity.Y > maxPosition {
+		x, y := randomPosition()
+		req.Entity.X = x
+		req.Entity.Y = y
 	}
 
 	// Make sure the cell is not occupied
@@ -388,11 +387,12 @@ func (s *environmentServer) ExecuteAgentAction(ctx context.Context, req *envApi.
 			}
 			entityID := newUUID.String()
 			// Create entity
+			x, y := randomPosition()
 			e := envApi.Entity{
 				Id:      entityID,
 				ClassID: 3,
-				X:       uint32(rand.Intn(100)),
-				Y:       uint32(rand.Intn(100)),
+				X:       x,
+				Y:       y,
 			}
 			// Create entity silently (no publish)
 			err = s.datacomDAL.CreateEntity(e, true)

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -72,6 +72,8 @@ type DataAccessLayer interface {
 	GetRemoteModelMetadataBySecret(modelSecret string) (*datacom.RemoteModel, error)
 	GetRemoteModelMetadataByID(modelID string) (*datacom.RemoteModel, error)
 	UpdateRemoteModelMetadata(remoteModelMD *datacom.RemoteModel, connectCount int) error
+	AddEntityMetadataToFireabse(envApi.Entity) error
+	RemoveEntityMetadataFromFirebase(id string) error
 }
 
 // NewEnvironmentServer creates simulation service
@@ -195,6 +197,8 @@ func (s *environmentServer) CreateEntity(ctx context.Context, req *envApi.Create
 
 	// Add the entity to the environment
 	err = s.datacomDAL.CreateEntity(*req.Entity, true)
+	// Add metadata to firebase
+	err = s.datacomDAL.AddEntityMetadataToFireabse(*req.Entity)
 
 	// Return the data for the agent
 	return &envApi.CreateEntityResponse{
@@ -230,6 +234,13 @@ func (s *environmentServer) DeleteEntity(ctx context.Context, req *envApi.Delete
 	// Remove the entity from the environment
 	deleted, err := s.datacomDAL.DeleteEntity(req.Id)
 	if err != nil {
+		log.Printf("ERROR: %v", err)
+		return nil, err
+	}
+	// Remove entity from firebase
+	err = s.datacomDAL.RemoveEntityMetadataFromFirebase(req.Id)
+	if err != nil {
+		log.Printf("ERROR: %v", err)
 		return nil, err
 	}
 

--- a/pkg/environment/environment.go
+++ b/pkg/environment/environment.go
@@ -72,7 +72,7 @@ type DataAccessLayer interface {
 	GetRemoteModelMetadataBySecret(modelSecret string) (*datacom.RemoteModel, error)
 	GetRemoteModelMetadataByID(modelID string) (*datacom.RemoteModel, error)
 	UpdateRemoteModelMetadata(remoteModelMD *datacom.RemoteModel, connectCount int) error
-	AddEntityMetadataToFireabse(envApi.Entity) error
+	AddEntityMetadataToFireabase(envApi.Entity) error
 	RemoveEntityMetadataFromFirebase(id string) error
 }
 
@@ -198,7 +198,7 @@ func (s *environmentServer) CreateEntity(ctx context.Context, req *envApi.Create
 	// Add the entity to the environment
 	err = s.datacomDAL.CreateEntity(*req.Entity, true)
 	// Add metadata to firebase
-	err = s.datacomDAL.AddEntityMetadataToFireabse(*req.Entity)
+	err = s.datacomDAL.AddEntityMetadataToFireabase(*req.Entity)
 
 	// Return the data for the agent
 	return &envApi.CreateEntityResponse{
@@ -288,6 +288,7 @@ func (s *environmentServer) ExecuteAgentAction(ctx context.Context, req *envApi.
 		} else {
 			// KILL
 			s.datacomDAL.DeleteEntity(entity.Id)
+			s.datacomDAL.RemoveEntityMetadataFromFirebase(entity.Id)
 			return &envApi.ExecuteAgentActionResponse{
 				Value: envApi.ExecuteAgentActionResponse_ERR_DIED,
 			}, nil
@@ -320,6 +321,7 @@ func (s *environmentServer) ExecuteAgentAction(ctx context.Context, req *envApi.
 			} else {
 				// KILL
 				s.datacomDAL.DeleteEntity(entity.Id)
+				s.datacomDAL.RemoveEntityMetadataFromFirebase(entity.Id)
 				return &envApi.ExecuteAgentActionResponse{
 					Value: envApi.ExecuteAgentActionResponse_ERR_DIED,
 				}, nil
@@ -423,6 +425,7 @@ func (s *environmentServer) ExecuteAgentAction(ctx context.Context, req *envApi.
 			} else {
 				// KILL
 				s.datacomDAL.DeleteEntity(entity.Id)
+				s.datacomDAL.RemoveEntityMetadataFromFirebase(entity.Id)
 				return &envApi.ExecuteAgentActionResponse{
 					Value: envApi.ExecuteAgentActionResponse_ERR_DIED,
 				}, nil
@@ -439,6 +442,7 @@ func (s *environmentServer) ExecuteAgentAction(ctx context.Context, req *envApi.
 		} else {
 			// KILL
 			s.datacomDAL.DeleteEntity(other.Id)
+			s.datacomDAL.RemoveEntityMetadataFromFirebase(other.Id)
 		}
 
 	default: // INVALID

--- a/pkg/environment/environment_test.go
+++ b/pkg/environment/environment_test.go
@@ -272,7 +272,7 @@ func TestCreateEntity(t *testing.T) {
 					resp: []interface{}{nil},
 				},
 				{ // Add entity to firebase
-					name: "AddEntityMetadataToFireabse",
+					name: "AddEntityMetadataToFireabase",
 					args: []interface{}{envApi.Entity{Id: "0", ClassID: 1, X: uint32(25), Y: uint32(25), Energy: uint32(100), Health: uint32(100), OwnerUID: "MOCK-UID", ModelID: "mock-model-id"}},
 					resp: []interface{}{nil},
 				},
@@ -318,7 +318,7 @@ func TestCreateEntity(t *testing.T) {
 					resp: []interface{}{nil},
 				},
 				{ // Add entity to firebase
-					name: "AddEntityMetadataToFireabse",
+					name: "AddEntityMetadataToFireabase",
 					args: []interface{}{envApi.Entity{Id: "0", ClassID: 1, X: uint32(1), Y: uint32(1), Energy: uint32(100), Health: uint32(100), OwnerUID: "MOCK-UID", ModelID: "mock-model-id"}},
 					resp: []interface{}{nil},
 				},
@@ -470,7 +470,7 @@ func TestDeleteEntity(t *testing.T) {
 					args: []interface{}{""},
 					resp: []interface{}{int64(1), nil},
 				},
-				{
+				{ // Remove agents MD
 					name: "RemoveEntityMetadataFromFirebase",
 					args: []interface{}{""},
 					resp: []interface{}{nil},
@@ -656,6 +656,11 @@ func TestExecuteAgentAction(t *testing.T) {
 					args: []interface{}{"mock-entity-id"},
 					resp: []interface{}{int64(1), nil},
 				},
+				{ // Create a new food entity somewhere
+					name: "RemoveEntityMetadataFromFirebase",
+					args: []interface{}{"mock-entity-id"},
+					resp: []interface{}{nil},
+				},
 			},
 			want: &envApi.ExecuteAgentActionResponse{
 				Value: envApi.ExecuteAgentActionResponse_ERR_DIED,
@@ -694,6 +699,11 @@ func TestExecuteAgentAction(t *testing.T) {
 				},
 				{ // Create a new food entity somewhere
 					name: "CreateEntity",
+					args: []interface{}{mock.AnythingOfType("Entity"), true},
+					resp: []interface{}{nil},
+				},
+				{ // Create a new food entity somewhere
+					name: "AddEntityMetadataToFirebase",
 					args: []interface{}{mock.AnythingOfType("Entity"), true},
 					resp: []interface{}{nil},
 				},
@@ -828,7 +838,7 @@ func TestExecuteAgentAction(t *testing.T) {
 			},
 		},
 		{
-			name: "Succesful attack kills other, energy of this",
+			name: "Succesful attack kills other, adjusts energy of this",
 			args: args{
 				ctx: ctx,
 				req: &envApi.ExecuteAgentActionRequest{
@@ -852,6 +862,11 @@ func TestExecuteAgentAction(t *testing.T) {
 					name: "DeleteEntity",
 					args: []interface{}{"mock-agent-id-2"},
 					resp: []interface{}{int64(1), nil},
+				},
+				{ // Remove other agents MD
+					name: "RemoveEntityMetadataFromFirebase",
+					args: []interface{}{"mock-agent-id-2"},
+					resp: []interface{}{nil},
 				},
 				{ // Update this agent
 					name: "UpdateEntity",

--- a/pkg/environment/environment_test.go
+++ b/pkg/environment/environment_test.go
@@ -177,15 +177,15 @@ func TestCreateEntity(t *testing.T) {
 			wantErr: errors.New("you can only manually create 5 entities at a time"),
 		},
 		{
-			name: "Invalid position (over max position)",
+			name: "Invalid position places in random valid position",
 			args: args{
 				ctx: ctx,
 				req: &envApi.CreateEntityRequest{
 					Entity: &envApi.Entity{
 						ModelID:  "mock-model-id",
 						OwnerUID: "MOCK-UID",
-						X:        1000,
-						Y:        50,
+						X:        101,
+						Y:        0,
 					},
 				},
 			},
@@ -200,8 +200,13 @@ func TestCreateEntity(t *testing.T) {
 					args: []interface{}{"mock-model-id"},
 					resp: []interface{}{[]envApi.Entity{}, nil},
 				},
+				{ // Get entities for the RM
+					name: "IsCellOccupied",
+					args: []interface{}{mock.AnythingOfType("uint32"), mock.AnythingOfType("uint32")},
+					resp: []interface{}{true, nil, "", nil},
+				},
 			},
-			wantErr: errors.New("invalid position"),
+			wantErr: errors.New("cell is already occupied"),
 		},
 		{
 			name: "Cannot create entity in occupied cell",

--- a/pkg/environment/mocks/DataAccessLayer.go
+++ b/pkg/environment/mocks/DataAccessLayer.go
@@ -13,8 +13,8 @@ type DataAccessLayer struct {
 	mock.Mock
 }
 
-// AddEntityMetadataToFireabse provides a mock function with given fields: _a0
-func (_m *DataAccessLayer) AddEntityMetadataToFireabse(_a0 endpoints_terrariumai_environment.Entity) error {
+// AddEntityMetadataToFireabase provides a mock function with given fields: _a0
+func (_m *DataAccessLayer) AddEntityMetadataToFireabase(_a0 endpoints_terrariumai_environment.Entity) error {
 	ret := _m.Called(_a0)
 
 	var r0 error

--- a/pkg/environment/mocks/DataAccessLayer.go
+++ b/pkg/environment/mocks/DataAccessLayer.go
@@ -13,6 +13,20 @@ type DataAccessLayer struct {
 	mock.Mock
 }
 
+// AddEntityMetadataToFireabse provides a mock function with given fields: _a0
+func (_m *DataAccessLayer) AddEntityMetadataToFireabse(_a0 endpoints_terrariumai_environment.Entity) error {
+	ret := _m.Called(_a0)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(endpoints_terrariumai_environment.Entity) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // CreateEffect provides a mock function with given fields: _a0
 func (_m *DataAccessLayer) CreateEffect(_a0 endpoints_terrariumai_environment.Effect) error {
 	ret := _m.Called(_a0)
@@ -265,6 +279,20 @@ func (_m *DataAccessLayer) IsCellOccupied(x uint32, y uint32) (bool, *endpoints_
 	}
 
 	return r0, r1, r2, r3
+}
+
+// RemoveEntityMetadataFromFirebase provides a mock function with given fields: id
+func (_m *DataAccessLayer) RemoveEntityMetadataFromFirebase(id string) error {
+	ret := _m.Called(id)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(id)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // UpdateEntity provides a mock function with given fields: origionalContent, e


### PR DESCRIPTION
When entities are created and deleted their core metadata is added to firebase
- This enables web clients to consume this information and display stats and leaderboards!